### PR TITLE
Replacing incorrect import from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-from distutils.core import setup
+from setuptools import setup
 import os
 
 


### PR DESCRIPTION
Replacing incorrect import from distutils to setuptools. The setup using distutils will error out.
