### PR TITLE
A minor change to setup.py to enable running test using python setup.py test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,5 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
     ],
+    test_suite="unittests",
 )


### PR DESCRIPTION
This little change will enable tests to be run using `python setup.py test`
